### PR TITLE
fix(standards): add declare(strict_types=1) to Livewire components

### DIFF
--- a/src/Website/Hub/View/Modal/Admin/Console.php
+++ b/src/Website/Hub/View/Modal/Admin/Console.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Website\Hub\View\Modal\Admin;
 
 use Livewire\Component;

--- a/src/Website/Hub/View/Modal/Admin/ContentEditor.php
+++ b/src/Website/Hub/View/Modal/Admin/ContentEditor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Website\Hub\View\Modal\Admin;
 
 use Core\Mod\Content\Enums\ContentType;

--- a/src/Website/Hub/View/Modal/Admin/ContentManager.php
+++ b/src/Website/Hub/View/Modal/Admin/ContentManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Website\Hub\View\Modal\Admin;
 
 use Core\Cdn\Services\BunnyCdnService;

--- a/src/Website/Hub/View/Modal/Admin/Platform.php
+++ b/src/Website/Hub/View/Modal/Admin/Platform.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Website\Hub\View\Modal\Admin;
 
 use Core\Tenant\Enums\UserTier;

--- a/src/Website/Hub/View/Modal/Admin/PlatformUser.php
+++ b/src/Website/Hub/View/Modal/Admin/PlatformUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Website\Hub\View\Modal\Admin;
 
 use Illuminate\Support\Facades\DB;

--- a/src/Website/Hub/View/Modal/Admin/Profile.php
+++ b/src/Website/Hub/View/Modal/Admin/Profile.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Website\Hub\View\Modal\Admin;
 
 use Core\Tenant\Enums\UserTier;

--- a/src/Website/Hub/View/Modal/Admin/Settings.php
+++ b/src/Website/Hub/View/Modal/Admin/Settings.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Website\Hub\View\Modal\Admin;
 
 use Flux\Flux;


### PR DESCRIPTION
## Summary
Added `declare(strict_types=1);` to 7 Livewire components that were missing it.

## Changes
- Console.php
- Platform.php
- PlatformUser.php
- Profile.php
- Settings.php
- ContentManager.php
- ContentEditor.php

Note: `Mod/Hub/Boot.php` listed in the issue already had the declaration.

## Test Plan
- [ ] CI tests pass
- [ ] All affected components still render correctly

Closes #15

---
Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code quality improvements to strengthen type safety across admin console components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->