### PR TITLE
fix(honeypot): add missing severity column to migration

### DIFF
--- a/src/Mod/Hub/Migrations/2026_01_11_000001_create_honeypot_hits_table.php
+++ b/src/Mod/Hub/Migrations/2026_01_11_000001_create_honeypot_hits_table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -20,11 +22,13 @@ return new class extends Migration
             $table->string('city', 100)->nullable();
             $table->boolean('is_bot')->default(false);
             $table->string('bot_name', 100)->nullable();
+            $table->string('severity', 20)->default('warning');
             $table->timestamps();
 
             $table->index('ip_address');
             $table->index('created_at');
             $table->index('is_bot');
+            $table->index('severity');
         });
     }
 


### PR DESCRIPTION
## Summary
Adds the missing `severity` column to the honeypot_hits migration.

## Problem
The `HoneypotHit` model expects a `severity` column for categorising hits (warning, critical, etc.), but the migration didn't create it. This would cause database errors when honeypots are triggered in production.

## Changes
- Added `severity` column (varchar 20, default 'warning')
- Added index on `severity` for query performance
- Added `declare(strict_types=1)` for consistency

## Test Plan
- [ ] CI passes
- [ ] Fresh migration creates severity column
- [ ] Honeypot hits can be categorised by severity

Closes #6

---
Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema to enhance honeypot hit tracking with severity level classification, enabling better categorization and monitoring of suspicious activities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->